### PR TITLE
feat(rwnd): add rwnd trace and its unit test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,12 +43,14 @@ model = [
   "delay-per-packet-model",
   "loss-model",
   "duplicate-model",
+  "rwnd-model",
 ]
 bw-model = ["dep:rand", "dep:rand_distr", "dep:dyn-clone"]
 delay-model = ["dep:dyn-clone"]
 delay-per-packet-model = ["dep:dyn-clone"]
 loss-model = ["dep:dyn-clone"]
 duplicate-model = ["dep:dyn-clone"]
+rwnd-model = ["dep:dyn-clone"]
 serde = ["dep:serde", "dep:typetag", "bandwidth/serde"]
 mahimahi = ["dep:itertools"]
 human = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,6 +113,7 @@ pub use mahimahi::{load_mahimahi_trace, Mahimahi, MahimahiExt};
     feature = "delay-model",
     feature = "loss-model",
     feature = "duplicate-model",
+    feature = "rwnd-model",
     feature = "model",
 ))]
 pub mod model;
@@ -125,6 +126,14 @@ pub use std::time::Duration;
 
 /// The delay describes how long a packet is delayed when going through.
 pub type Delay = std::time::Duration;
+
+/// A receive window value in bytes.
+///
+/// Used for `set_rcv_buf`, `app_read_bytes`, and `rwnd_remaining` fields in
+/// [`RwndDecision`]. All three are byte counts even though they describe
+/// different things (a configured buffer size, a consumed amount, an observed
+/// remaining window), so they share a single integer type.
+pub type Rwnd = u64;
 
 /// The loss_pattern describes how the packets are dropped when going through.
 ///
@@ -235,6 +244,58 @@ pub trait LossTrace: Send {
 /// the sequence, or **None** if the trace goes to end.
 pub trait DuplicateTrace: Send {
     fn next_duplicate(&mut self) -> Option<(DuplicatePattern, Duration)>;
+}
+
+/// The action a rwnd trace instructs the receiver to take at a single step.
+///
+/// Exactly one variant is present per step — the type-level encoding of the
+/// "exactly one of `app_read_bytes` / `rwnd_remaining`" rule.
+///
+/// - `AppRead` drives the receiver model by simulating the application reading
+///   `bytes` from the receive buffer; the resulting rwnd is computed from the
+///   buffer state.
+/// - `Remaining` skips the simulation and directly enforces an observed rwnd
+///   of `rwnd` bytes — useful for replaying captured traces where only the
+///   advertised window is known.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RwndAction {
+    /// The simulated application reads this many bytes from the receive buffer at this step.
+    AppRead { bytes: u64 },
+    /// The remaining rwnd value observed immediately after the app consumes data at this step.
+    Remaining { rwnd: u64 },
+}
+
+/// A single receive-side decision emitted by a [`RwndTrace`].
+///
+/// Each step of a rwnd trace produces one `RwndDecision` paired with a
+/// [`Duration`] (see [`RwndTrace`]). The `set_rcv_buf` field is optional and
+/// independent of [`RwndAction`]: a step may resize the socket's receive
+/// buffer at the same time it advances the app-read or observed-remaining state.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RwndDecision {
+    /// If `Some`, reconfigure the socket's receive buffer to this size at this step.
+    pub set_rcv_buf: Option<u64>,
+    /// The app-read or observed-remaining action for this step.
+    pub action: RwndAction,
+}
+
+/// This is a trait that represents a trace of receive-window decisions over time.
+///
+/// The trace is a sequence of `(rwnd_decision, duration)` pairs. The decision
+/// describes how the socket's receive buffer, the application's read behavior,
+/// and/or the observed remaining window change at this step; the duration is
+/// how long this configuration lasts before the next step applies.
+///
+/// For example, if the sequence is
+/// `[(set_rcv_buf=64KB, app_read=1KB, 1s), (rwnd_remaining=32KB, 2s)]`,
+/// then the receive buffer is resized to 64KB and the app reads 1KB for 1s,
+/// then the observed rwnd becomes 32KB for 2s.
+///
+/// Each `next_rwnd` call returns **the next decision and its duration** in the
+/// sequence, or **None** when the trace is exhausted. Mirrors the shape of
+/// [`BwTrace`], [`DelayTrace`], and [`LossTrace`].
+pub trait RwndTrace: Send {
+    fn next_rwnd(&mut self) -> Option<(RwndDecision, Duration)>;
 }
 
 #[cfg(test)]

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,15 +1,16 @@
-//! This module contains pre-defined models for BwTrace, DelayTrace, LossTrace and DuplicateTrace.
+//! This module contains pre-defined models for BwTrace, DelayTrace, LossTrace, DuplicateTrace and RwndTrace.
 //!
 //! A model has two parts: a configuration struct and a model struct.
 //! The configuration struct is used to configure the model and
 //! used for serialization/deserialization if `serde` feature is enabled.
-//! The model struct which implements trait `BwTrace`, `DelayTrace`, `LossTrace` or `DuplicateTrace`
+//! The model struct which implements trait `BwTrace`, `DelayTrace`, `LossTrace`, `DuplicateTrace` or `RwndTrace`
 //! is used to generate the trace and maintain inner states.
 //!
 //! Enable `bw-model` feature to use the BwTrace models.
 //! Enable `delay-model` feature to use the DelayTrace models.
 //! Enable `loss-model` feature to use the LossTrace models.
 //! Enable `duplicate-model` feature to use the DuplicateTrace models.
+//! Enable `rwnd-model` feature to use the RwndTrace models.
 
 #[cfg(feature = "bw-model")]
 pub mod bw;
@@ -59,6 +60,14 @@ pub mod duplicate;
 pub use duplicate::{DuplicateTraceConfig, RepeatedDuplicatePatternConfig, StaticDuplicateConfig};
 #[cfg(feature = "duplicate-model")]
 pub use duplicate::{RepeatedDuplicatePattern, StaticDuplicate};
+
+#[cfg(feature = "rwnd-model")]
+pub mod rwnd;
+
+#[cfg(feature = "rwnd-model")]
+pub use rwnd::{RepeatedRwndPattern, StaticRwnd};
+#[cfg(feature = "rwnd-model")]
+pub use rwnd::{RepeatedRwndPatternConfig, RwndActionConfig, RwndTraceConfig, StaticRwndConfig};
 
 #[cfg(feature = "truncated-normal")]
 pub mod solve_truncate;

--- a/src/model/rwnd.rs
+++ b/src/model/rwnd.rs
@@ -1,0 +1,538 @@
+//! This module contains some predefined rwnd trace models.
+//!
+//! Enabled with feature `rwnd-model` or `model`.
+//!
+//! ## Predefined models
+//!
+//! - [`StaticRwnd`]: A trace model with a single rwnd decision.
+//! - [`RepeatedRwndPattern`]: A trace model with a repeated rwnd pattern.
+//!
+//! ## Examples
+//!
+//! An example to build model from configuration:
+//!
+//! ```
+//! # use netem_trace::model::StaticRwndConfig;
+//! # use netem_trace::{Duration, RwndTrace, RwndAction};
+//! let mut static_rwnd = StaticRwndConfig::new()
+//!     .set_rcv_buf(65536)
+//!     .app_read(1024)
+//!     .duration(Duration::from_secs(1))
+//!     .build();
+//! let (decision, duration) = static_rwnd.next_rwnd().unwrap();
+//! assert_eq!(decision.set_rcv_buf, Some(65536));
+//! assert_eq!(decision.action, RwndAction::AppRead { bytes: 1024 });
+//! assert_eq!(duration, Duration::from_secs(1));
+//! assert_eq!(static_rwnd.next_rwnd(), None);
+//! ```
+//!
+//! A more common use case is to build model from a configuration file (e.g. json file):
+//!
+//! ```
+//! # use netem_trace::model::{StaticRwndConfig, RwndTraceConfig};
+//! # use netem_trace::{Duration, RwndTrace, RwndAction};
+//! # #[cfg(feature = "human")]
+//! # let config_file_content = "{\"RepeatedRwndPatternConfig\":{\"pattern\":[{\"StaticRwndConfig\":{\"duration\":\"1s\",\"set_rcv_buf\":65536,\"app_read_bytes\":1024}},{\"StaticRwndConfig\":{\"duration\":\"1s\",\"rwnd_remaining\":32768}}],\"count\":2}}";
+//! // The content would be "{\"RepeatedRwndPatternConfig\":{\"pattern\":[{\"StaticRwndConfig\":{\"duration\":{\"secs\":1,\"nanos\":0},\"set_rcv_buf\":65536,\"app_read_bytes\":1024}},{\"StaticRwndConfig\":{\"duration\":{\"secs\":1,\"nanos\":0},\"rwnd_remaining\":32768}}],\"count\":2}}"
+//! // if the `human` feature is not enabled.
+//! # #[cfg(not(feature = "human"))]
+//! let config_file_content = "{\"RepeatedRwndPatternConfig\":{\"pattern\":[{\"StaticRwndConfig\":{\"duration\":{\"secs\":1,\"nanos\":0},\"set_rcv_buf\":65536,\"app_read_bytes\":1024}},{\"StaticRwndConfig\":{\"duration\":{\"secs\":1,\"nanos\":0},\"rwnd_remaining\":32768}}],\"count\":2}}";
+//! let des: Box<dyn RwndTraceConfig> = serde_json::from_str(config_file_content).unwrap();
+//! let mut model = des.into_model();
+//! let (decision, _) = model.next_rwnd().unwrap();
+//! assert_eq!(decision.action, RwndAction::AppRead { bytes: 1024 });
+//! let (decision, _) = model.next_rwnd().unwrap();
+//! assert_eq!(decision.action, RwndAction::Remaining { rwnd: 32768 });
+//! let (decision, _) = model.next_rwnd().unwrap();
+//! assert_eq!(decision.action, RwndAction::AppRead { bytes: 1024 });
+//! let (decision, _) = model.next_rwnd().unwrap();
+//! assert_eq!(decision.action, RwndAction::Remaining { rwnd: 32768 });
+//! assert_eq!(model.next_rwnd(), None);
+//! ```
+//!
+//! Each step must set **exactly one** of `app_read_bytes` or `rwnd_remaining` —
+//! never both, never neither. A step that violates this rule fails to deserialize
+//! with a clear error message; a programmatically-built config that violates it
+//! panics in [`StaticRwndConfig::build`].
+use crate::{Duration, Rwnd, RwndAction, RwndDecision, RwndTrace};
+use dyn_clone::DynClone;
+
+/// This trait is used to convert a rwnd trace configuration into a rwnd trace model.
+///
+/// Since trace model is often configured with files and often has inner states which
+/// is not suitable to be serialized/deserialized, this trait makes it possible to
+/// separate the configuration part into a simple struct for serialization/deserialization, and
+/// construct the model from the configuration.
+#[cfg_attr(feature = "serde", typetag::serde)]
+pub trait RwndTraceConfig: DynClone + Send {
+    fn into_model(self: Box<Self>) -> Box<dyn RwndTrace>;
+}
+
+dyn_clone::clone_trait_object!(RwndTraceConfig);
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// The config-layer representation of the action at a rwnd step.
+///
+/// This enum is the deserialized form of the mutually-exclusive
+/// `app_read_bytes` / `rwnd_remaining` pair. [`StaticRwndConfig`]'s custom
+/// serde impls flatten the active variant into the top level of the JSON
+/// object, so this enum's own externally-tagged shape is rarely seen by users
+/// — but it's serialized/deserialized on its own when used outside the
+/// custom container impl.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
+pub enum RwndActionConfig {
+    AppRead { app_read_bytes: Rwnd },
+    Remaining { rwnd_remaining: Rwnd },
+}
+
+/// The model of a static rwnd trace: a single decision valid for one duration.
+///
+/// ## Examples
+///
+/// ```
+/// # use netem_trace::model::StaticRwndConfig;
+/// # use netem_trace::{Duration, RwndTrace, RwndAction};
+/// let mut static_rwnd = StaticRwndConfig::new()
+///     .set_rcv_buf(65536)
+///     .app_read(1024)
+///     .duration(Duration::from_secs(1))
+///     .build();
+/// let (decision, duration) = static_rwnd.next_rwnd().unwrap();
+/// assert_eq!(decision.set_rcv_buf, Some(65536));
+/// assert_eq!(decision.action, RwndAction::AppRead { bytes: 1024 });
+/// assert_eq!(duration, Duration::from_secs(1));
+/// assert_eq!(static_rwnd.next_rwnd(), None);
+/// ```
+#[derive(Debug, Clone)]
+pub struct StaticRwnd {
+    pub decision: RwndDecision,
+    pub duration: Option<Duration>,
+}
+
+/// The configuration struct for [`StaticRwnd`].
+///
+/// The serialized JSON form is **flat** — the active variant of [`RwndActionConfig`]
+/// is hoisted to the top level, so a step looks like
+/// `{"duration":"1s","set_rcv_buf":65536,"app_read_bytes":1024}` (or
+/// `{"duration":"1s","rwnd_remaining":32768}`), never with an `action` wrapper.
+///
+/// Exactly one of `app_read_bytes` / `rwnd_remaining` must be set; the deserializer
+/// rejects both-set and neither-set inputs.
+#[derive(Debug, Clone, Default)]
+pub struct StaticRwndConfig {
+    pub duration: Option<Duration>,
+    pub set_rcv_buf: Option<Rwnd>,
+    // None only when constructed via `new()`/`Default` and not yet configured;
+    // `build()` panics on None as a defense for programmatic construction.
+    pub action: Option<RwndActionConfig>,
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for StaticRwndConfig {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(Deserialize, Default)]
+        #[serde(default)]
+        struct Helper {
+            #[cfg_attr(feature = "human", serde(with = "humantime_serde"))]
+            #[serde(default)]
+            duration: Option<Duration>,
+            #[serde(default)]
+            set_rcv_buf: Option<Rwnd>,
+            #[serde(default)]
+            app_read_bytes: Option<Rwnd>,
+            #[serde(default)]
+            rwnd_remaining: Option<Rwnd>,
+        }
+
+        let h = Helper::deserialize(deserializer)?;
+        let action = match (h.app_read_bytes, h.rwnd_remaining) {
+            (Some(bytes), None) => RwndActionConfig::AppRead {
+                app_read_bytes: bytes,
+            },
+            (None, Some(rwnd)) => RwndActionConfig::Remaining {
+                rwnd_remaining: rwnd,
+            },
+            (Some(_), Some(_)) => {
+                return Err(serde::de::Error::custom(
+                    "rwnd step cannot set both `app_read_bytes` and `rwnd_remaining`",
+                ));
+            }
+            (None, None) => {
+                return Err(serde::de::Error::custom(
+                    "rwnd step must set exactly one of `app_read_bytes` or `rwnd_remaining`",
+                ));
+            }
+        };
+        Ok(Self {
+            duration: h.duration,
+            set_rcv_buf: h.set_rcv_buf,
+            action: Some(action),
+        })
+    }
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for StaticRwndConfig {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        #[derive(Serialize)]
+        struct Out {
+            #[serde(skip_serializing_if = "Option::is_none")]
+            #[cfg_attr(feature = "human", serde(with = "humantime_serde"))]
+            duration: Option<Duration>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            set_rcv_buf: Option<Rwnd>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            app_read_bytes: Option<Rwnd>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            rwnd_remaining: Option<Rwnd>,
+        }
+
+        let (app_read_bytes, rwnd_remaining) = match &self.action {
+            Some(RwndActionConfig::AppRead { app_read_bytes }) => (Some(*app_read_bytes), None),
+            Some(RwndActionConfig::Remaining { rwnd_remaining }) => (None, Some(*rwnd_remaining)),
+            None => (None, None),
+        };
+        Out {
+            duration: self.duration,
+            set_rcv_buf: self.set_rcv_buf,
+            app_read_bytes,
+            rwnd_remaining,
+        }
+        .serialize(serializer)
+    }
+}
+
+/// The model contains an array of rwnd trace models.
+///
+/// Combine multiple rwnd trace models into one rwnd pattern,
+/// and repeat the pattern for `count` times.
+///
+/// If `count` is 0, the pattern will be repeated forever.
+///
+/// ## Examples
+///
+/// The most common use case is to read from a configuration file and
+/// deserialize it into a [`RepeatedRwndPatternConfig`]:
+///
+/// ```
+/// # use netem_trace::model::{StaticRwndConfig, RwndTraceConfig};
+/// # use netem_trace::{Duration, RwndTrace, RwndAction};
+/// # #[cfg(feature = "human")]
+/// # let config_file_content = "{\"RepeatedRwndPatternConfig\":{\"pattern\":[{\"StaticRwndConfig\":{\"duration\":\"1s\",\"set_rcv_buf\":65536,\"app_read_bytes\":1024}},{\"StaticRwndConfig\":{\"duration\":\"1s\",\"rwnd_remaining\":32768}}],\"count\":2}}";
+/// # #[cfg(not(feature = "human"))]
+/// let config_file_content = "{\"RepeatedRwndPatternConfig\":{\"pattern\":[{\"StaticRwndConfig\":{\"duration\":{\"secs\":1,\"nanos\":0},\"set_rcv_buf\":65536,\"app_read_bytes\":1024}},{\"StaticRwndConfig\":{\"duration\":{\"secs\":1,\"nanos\":0},\"rwnd_remaining\":32768}}],\"count\":2}}";
+/// let des: Box<dyn RwndTraceConfig> = serde_json::from_str(config_file_content).unwrap();
+/// let mut model = des.into_model();
+/// let (decision, _) = model.next_rwnd().unwrap();
+/// assert_eq!(decision.action, RwndAction::AppRead { bytes: 1024 });
+/// ```
+pub struct RepeatedRwndPattern {
+    pub pattern: Vec<Box<dyn RwndTraceConfig>>,
+    pub count: usize,
+    current_model: Option<Box<dyn RwndTrace>>,
+    current_cycle: usize,
+    current_pattern: usize,
+}
+
+/// The configuration struct for [`RepeatedRwndPattern`].
+///
+/// See [`RepeatedRwndPattern`] for more details.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(default))]
+#[derive(Default, Clone)]
+pub struct RepeatedRwndPatternConfig {
+    pub pattern: Vec<Box<dyn RwndTraceConfig>>,
+    pub count: usize,
+}
+
+impl RwndTrace for StaticRwnd {
+    fn next_rwnd(&mut self) -> Option<(RwndDecision, Duration)> {
+        if let Some(duration) = self.duration.take() {
+            if duration.is_zero() {
+                None
+            } else {
+                Some((self.decision.clone(), duration))
+            }
+        } else {
+            None
+        }
+    }
+}
+
+impl RwndTrace for RepeatedRwndPattern {
+    fn next_rwnd(&mut self) -> Option<(RwndDecision, Duration)> {
+        if self.pattern.is_empty() || (self.count != 0 && self.current_cycle >= self.count) {
+            None
+        } else {
+            if self.current_model.is_none() {
+                self.current_model = Some(self.pattern[self.current_pattern].clone().into_model());
+            }
+            match self.current_model.as_mut().unwrap().next_rwnd() {
+                Some(rwnd) => Some(rwnd),
+                None => {
+                    self.current_model = None;
+                    self.current_pattern += 1;
+                    if self.current_pattern >= self.pattern.len() {
+                        self.current_pattern = 0;
+                        self.current_cycle += 1;
+                        if self.count != 0 && self.current_cycle >= self.count {
+                            return None;
+                        }
+                    }
+                    self.next_rwnd()
+                }
+            }
+        }
+    }
+}
+
+impl StaticRwndConfig {
+    pub fn new() -> Self {
+        Self {
+            duration: None,
+            set_rcv_buf: None,
+            action: None,
+        }
+    }
+
+    pub fn duration(mut self, duration: Duration) -> Self {
+        self.duration = Some(duration);
+        self
+    }
+
+    pub fn set_rcv_buf(mut self, set_rcv_buf: Rwnd) -> Self {
+        self.set_rcv_buf = Some(set_rcv_buf);
+        self
+    }
+
+    pub fn app_read(mut self, bytes: Rwnd) -> Self {
+        self.action = Some(RwndActionConfig::AppRead {
+            app_read_bytes: bytes,
+        });
+        self
+    }
+
+    pub fn remaining(mut self, rwnd: Rwnd) -> Self {
+        self.action = Some(RwndActionConfig::Remaining {
+            rwnd_remaining: rwnd,
+        });
+        self
+    }
+
+    pub fn build(self) -> StaticRwnd {
+        let action_cfg = self.action.expect(
+            "StaticRwndConfig::build called without setting one of `app_read_bytes` or `rwnd_remaining`",
+        );
+        let action = match action_cfg {
+            RwndActionConfig::AppRead { app_read_bytes } => RwndAction::AppRead {
+                bytes: app_read_bytes,
+            },
+            RwndActionConfig::Remaining { rwnd_remaining } => RwndAction::Remaining {
+                rwnd: rwnd_remaining,
+            },
+        };
+        StaticRwnd {
+            decision: RwndDecision {
+                set_rcv_buf: self.set_rcv_buf,
+                action,
+            },
+            duration: Some(self.duration.unwrap_or_else(|| Duration::from_secs(1))),
+        }
+    }
+}
+
+impl RepeatedRwndPatternConfig {
+    pub fn new() -> Self {
+        Self {
+            pattern: vec![],
+            count: 0,
+        }
+    }
+
+    pub fn pattern(mut self, pattern: Vec<Box<dyn RwndTraceConfig>>) -> Self {
+        self.pattern = pattern;
+        self
+    }
+
+    pub fn count(mut self, count: usize) -> Self {
+        self.count = count;
+        self
+    }
+
+    pub fn build(self) -> RepeatedRwndPattern {
+        RepeatedRwndPattern {
+            pattern: self.pattern,
+            count: self.count,
+            current_model: None,
+            current_cycle: 0,
+            current_pattern: 0,
+        }
+    }
+}
+
+macro_rules! impl_rwnd_trace_config {
+    ($name:ident) => {
+        #[cfg_attr(feature = "serde", typetag::serde)]
+        impl RwndTraceConfig for $name {
+            fn into_model(self: Box<$name>) -> Box<dyn RwndTrace> {
+                Box::new(self.build())
+            }
+        }
+    };
+}
+
+impl_rwnd_trace_config!(StaticRwndConfig);
+impl_rwnd_trace_config!(RepeatedRwndPatternConfig);
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::model::StaticRwndConfig;
+    use crate::RwndTrace;
+
+    #[test]
+    fn test_static_rwnd_model_app_read() {
+        let mut static_rwnd = StaticRwndConfig::new()
+            .set_rcv_buf(65536)
+            .app_read(1024)
+            .duration(Duration::from_secs(1))
+            .build();
+        let (decision, duration) = static_rwnd.next_rwnd().unwrap();
+        assert_eq!(decision.set_rcv_buf, Some(65536));
+        assert_eq!(decision.action, RwndAction::AppRead { bytes: 1024 });
+        assert_eq!(duration, Duration::from_secs(1));
+        assert_eq!(static_rwnd.next_rwnd(), None);
+    }
+
+    #[test]
+    fn test_static_rwnd_model_remaining() {
+        let mut static_rwnd = StaticRwndConfig::new()
+            .remaining(32768)
+            .duration(Duration::from_secs(2))
+            .build();
+        let (decision, duration) = static_rwnd.next_rwnd().unwrap();
+        assert_eq!(decision.set_rcv_buf, None);
+        assert_eq!(decision.action, RwndAction::Remaining { rwnd: 32768 });
+        assert_eq!(duration, Duration::from_secs(2));
+        assert_eq!(static_rwnd.next_rwnd(), None);
+    }
+
+    #[test]
+    fn test_repeated_rwnd_pattern() {
+        let pat = vec![
+            Box::new(
+                StaticRwndConfig::new()
+                    .app_read(1024)
+                    .duration(Duration::from_secs(1)),
+            ) as Box<dyn RwndTraceConfig>,
+            Box::new(
+                StaticRwndConfig::new()
+                    .remaining(32768)
+                    .duration(Duration::from_secs(1)),
+            ) as Box<dyn RwndTraceConfig>,
+        ];
+        let mut model = RepeatedRwndPatternConfig::new()
+            .pattern(pat)
+            .count(2)
+            .build();
+        let next = model.next_rwnd().unwrap();
+        assert_eq!(next.0.action, RwndAction::AppRead { bytes: 1024 });
+        assert_eq!(next.1, Duration::from_secs(1));
+        let next = model.next_rwnd().unwrap();
+        assert_eq!(next.0.action, RwndAction::Remaining { rwnd: 32768 });
+        let next = model.next_rwnd().unwrap();
+        assert_eq!(next.0.action, RwndAction::AppRead { bytes: 1024 });
+        let next = model.next_rwnd().unwrap();
+        assert_eq!(next.0.action, RwndAction::Remaining { rwnd: 32768 });
+        assert_eq!(model.next_rwnd(), None);
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_serde_roundtrip_app_read() {
+        let cfg = Box::new(
+            StaticRwndConfig::new()
+                .set_rcv_buf(65536)
+                .app_read(1024)
+                .duration(Duration::from_secs(1)),
+        ) as Box<dyn RwndTraceConfig>;
+        let ser_str = serde_json::to_string(&cfg).unwrap();
+        #[cfg(feature = "human")]
+        let expected = "{\"StaticRwndConfig\":{\"duration\":\"1s\",\"set_rcv_buf\":65536,\"app_read_bytes\":1024}}";
+        #[cfg(not(feature = "human"))]
+        let expected = "{\"StaticRwndConfig\":{\"duration\":{\"secs\":1,\"nanos\":0},\"set_rcv_buf\":65536,\"app_read_bytes\":1024}}";
+        assert_eq!(ser_str, expected);
+
+        let des: Box<dyn RwndTraceConfig> = serde_json::from_str(&ser_str).unwrap();
+        let mut model = des.into_model();
+        let (decision, duration) = model.next_rwnd().unwrap();
+        assert_eq!(decision.set_rcv_buf, Some(65536));
+        assert_eq!(decision.action, RwndAction::AppRead { bytes: 1024 });
+        assert_eq!(duration, Duration::from_secs(1));
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_serde_roundtrip_remaining() {
+        let cfg = Box::new(
+            StaticRwndConfig::new()
+                .remaining(32768)
+                .duration(Duration::from_secs(1)),
+        ) as Box<dyn RwndTraceConfig>;
+        let ser_str = serde_json::to_string(&cfg).unwrap();
+        #[cfg(feature = "human")]
+        let expected = "{\"StaticRwndConfig\":{\"duration\":\"1s\",\"rwnd_remaining\":32768}}";
+        #[cfg(not(feature = "human"))]
+        let expected = "{\"StaticRwndConfig\":{\"duration\":{\"secs\":1,\"nanos\":0},\"rwnd_remaining\":32768}}";
+        assert_eq!(ser_str, expected);
+
+        let des: Box<dyn RwndTraceConfig> = serde_json::from_str(&ser_str).unwrap();
+        let mut model = des.into_model();
+        let (decision, _) = model.next_rwnd().unwrap();
+        assert_eq!(decision.action, RwndAction::Remaining { rwnd: 32768 });
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_serde_rejects_both() {
+        // Omit duration to avoid the human/non-human format ambiguity; we're testing
+        // the action constraint, not duration parsing.
+        let json = "{\"StaticRwndConfig\":{\"app_read_bytes\":1024,\"rwnd_remaining\":32768}}";
+        let result: Result<Box<dyn RwndTraceConfig>, _> = serde_json::from_str(json);
+        let err = result
+            .err()
+            .expect("deserialization should have failed")
+            .to_string();
+        assert!(
+            err.contains("cannot set both"),
+            "expected 'cannot set both' in error, got: {err}"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_serde_rejects_neither() {
+        // Omit duration to avoid the human/non-human format ambiguity; we're testing
+        // the action constraint, not duration parsing.
+        let json = "{\"StaticRwndConfig\":{\"set_rcv_buf\":65536}}";
+        let result: Result<Box<dyn RwndTraceConfig>, _> = serde_json::from_str(json);
+        let err = result
+            .err()
+            .expect("deserialization should have failed")
+            .to_string();
+        assert!(
+            err.contains("exactly one"),
+            "expected 'exactly one' in error, got: {err}"
+        );
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "StaticRwndConfig::build called without setting one of `app_read_bytes` or `rwnd_remaining`"
+    )]
+    fn test_build_panics_without_action() {
+        StaticRwndConfig::new().build();
+    }
+}


### PR DESCRIPTION
This PR solves issue #25 

## Description

This PR adds receive window (rwnd) trace support to netem-trace, enabling simulation and replay of TCP receiver-side behaviour over time.

Each step in a rwnd trace is described by four fields:

- duration — how long this configuration lasts before the next step applies
- set_rcv_buf (optional) — resize the socket's receive buffer to this value at this step
- app_read_bytes (optional) — simulate the application reading this many bytes from the receive buffer (drives the receiver model)
- rwnd_remaining (optional) — directly assert the observed remaining receive window after consumption (useful for replaying captured traces)

Exactly one of app_read_bytes / rwnd_remaining must be set per step, never both and never neither. This invariant is enforced at two levels: deserialization rejects invalid inputs with a clear error message, and StaticRwndConfig::build() panics for programmatically-constructed configs that omit both.

New public surface in src/lib.rs:
- Rwnd — type alias (u64) for all byte-count fields
- RwndAction — enum encoding the mutually-exclusive action per step (AppRead { bytes } / Remaining { rwnd })
- RwndDecision — a single step's payload (set_rcv_buf + RwndAction)
- RwndTrace — trait mirroring BwTrace/DelayTrace/LossTrace, returning Option<(RwndDecision, Duration)>

New model module src/model/rwnd.rs (enabled via rwnd-model / model feature):
- StaticRwnd / StaticRwndConfig — single-step model with builder API
- RepeatedRwndPattern / RepeatedRwndPatternConfig — repeating pattern over a sequence of steps, with infinite-loop (count = 0) support
- RwndTraceConfig — config-to-model conversion trait, typetag-registered for serde polymorphism
- Custom Serialize/Deserialize for StaticRwndConfig that flattens app_read_bytes/rwnd_remaining to the top level of the JSON object (consistent with the flat style of other models)

The rwnd-model feature is added to the model umbrella feature and follows the same dependency pattern as loss-model and duplicate-model (dep:dyn-clone).

## How Has This Been Tested

- Unit tests (src/model/rwnd.rs #[cfg(test)] block):
  - test_static_rwnd_model_app_read — verifies AppRead step fields and exhaustion
  - test_static_rwnd_model_remaining — verifies Remaining step fields and exhaustion
  - test_repeated_rwnd_pattern — verifies a 2-step pattern repeated twice, then None
  - test_build_panics_without_action — confirms build() panics without an action set
  - test_serde_roundtrip_app_read — serialize → deserialize → assert field equality (#[cfg(feature = "serde")])
  - test_serde_roundtrip_remaining — same for Remaining variant
  - test_serde_rejects_both — confirms deserialization error when both fields are present
  - test_serde_rejects_neither — confirms deserialization error when neither field is present
- Doc tests on all public types and the module-level examples
- Tests run against --features "model,serde" (without human) and --features "model,serde,human" to confirm both duration-format paths work correctly. (The rejection tests were specifically written to avoid the "1s" human-format string to ensure they test the right thing regardless of features.)

cargo test --features "model,serde"        # 22 unit + 47 doc — all pass
cargo test --features "model,serde,human"  # 23 unit + 47 doc — all pass

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] Code follows the code style of this project.
- [x] Changes follow the CONTRIBUTING guidelines.
- [x] Update necessary documentation accordingly.
- [x] Lint and tests pass locally with the changes.
- [x] Check issues and pull requests first. You don't want to duplicate effort.

## Other information

The RwndAction / RwndDecision types are placed in lib.rs alongside BwTrace, LossTrace, etc., matching twnd-model feature follows the same opt-in pattern as other model features and is included in the modelumbrella and full feature set.
